### PR TITLE
Improve layout of LPD

### DIFF
--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -1,1 +1,74 @@
+body {
+    padding: 1.2rem;
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1rem;
+    font-weight: normal;
+    color: #313131;
+}
 
+.lpd, .likert-info {
+    margin-bottom: 1.2rem;
+}
+
+.section-title {
+    padding: 0.4rem;
+    cursor: pointer;
+}
+
+.section-title:hover {
+    background-color: #f2f2f2;
+    cursor: pointer;
+}
+
+.section-questions, .section-controls {
+    padding-left: 0.4rem;
+}
+
+.section-questions, .section-controls, .question {
+    margin-bottom: 2rem;
+}
+
+.question-number, .ranking-option > label:last-of-type, .likert-option > label:last-of-type {
+    margin-right: 1.4rem;
+}
+
+textarea.answer-text {
+    width: 60%;
+    min-height: 10rem;
+    padding: 0.8rem;
+}
+
+.question label, .ranking-option, .likert-option {
+    margin-bottom: 1rem;
+}
+
+.mc-options > label, .mr-options > label {
+    display: block;
+}
+
+.likert-info {
+    font-size: 0.9rem;
+    font-style: italic;
+}
+
+.custom-input {
+    margin-left: 0.6rem;
+}
+
+.section-submit {
+    box-shadow: none;
+    border-color: #0075b4;
+    border-style: solid;
+    border-radius: 0.1875rem;
+    border-width: 1px;
+    padding: 0.625rem 1.25rem;
+    background: #0075b4;
+    font-size: 1rem;
+    text-shadow: none;
+    color: #fcfcfc;
+    cursor: pointer;
+}
+
+.section-submit:hover {
+	background-color: #065683;
+}

--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -19,7 +19,7 @@ body {
     cursor: pointer;
 }
 
-.section-questions, .section-controls {
+#section-form > p, .section-questions, .section-controls {
     padding-left: 0.4rem;
 }
 

--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -5,7 +5,7 @@ body {
     color: #313131;
 }
 
-.lpd, .likert-info {
+.lpd, .framing-text, .likert-info {
     margin-bottom: 1.2rem;
 }
 
@@ -45,7 +45,7 @@ textarea.answer-text {
     display: block;
 }
 
-.likert-info {
+.framing-text, .likert-info {
     font-size: 0.9rem;
     font-style: italic;
 }

--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -5,7 +5,7 @@ body {
     color: #313131;
 }
 
-.lpd, .framing-text, .likert-info {
+.lpd, .question-framing, .likert-info {
     margin-bottom: 1.2rem;
 }
 
@@ -19,7 +19,12 @@ body {
     cursor: pointer;
 }
 
-#section-form > p, .section-questions, .section-controls {
+.section-intro {
+    margin-bottom: 1.6rem;
+    font-size: 0.95rem;
+}
+
+.section-intro, .section-questions, .section-controls {
     padding-left: 0.4rem;
 }
 
@@ -45,7 +50,7 @@ textarea.answer-text {
     display: block;
 }
 
-.framing-text, .likert-info {
+.question-framing, .likert-info {
     font-size: 0.9rem;
     font-style: italic;
 }

--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -2,7 +2,6 @@ body {
     padding: 1.2rem;
     font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 1rem;
-    font-weight: normal;
     color: #313131;
 }
 

--- a/app/static/js/lpd.js
+++ b/app/static/js/lpd.js
@@ -158,9 +158,11 @@ $(document).ready(function() {
 
     $('.section-title').click(function(e) {
         var $sectionForm = $(this).parent('form'),
+            $intro = $sectionForm.children('.section-intro'),
             $questions = $sectionForm.children('.section-questions'),
             $controls = $sectionForm.children('.section-controls');
 
+        $intro.toggle('slow');
         $questions.toggle('slow');
         $controls.toggle('slow');
     });

--- a/app/static/js/lpd.js
+++ b/app/static/js/lpd.js
@@ -161,8 +161,8 @@ $(document).ready(function() {
             $questions = $sectionForm.children('.section-questions'),
             $controls = $sectionForm.children('.section-controls');
 
-        $questions.toggle();
-        $controls.toggle();
+        $questions.toggle('slow');
+        $controls.toggle('slow');
     });
 
     $('.mr-option').click(function(e) {

--- a/lpd/migrations/0006_add_section_intro.py
+++ b/lpd/migrations/0006_add_section_intro.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lpd', '0005_collect_quantitative_data'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='section',
+            name='intro_text',
+            field=models.TextField(help_text=b'Introductory text to display below section title, and above questions belonging to this section (optional).', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='section',
+            name='title',
+            field=models.CharField(help_text=b'Text to display at the top of this section (optional).', max_length=120, null=True, blank=True),
+        ),
+    ]

--- a/lpd/migrations/0007_add_question_framing.py
+++ b/lpd/migrations/0007_add_question_framing.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lpd', '0006_add_section_intro'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='likertscalequestion',
+            name='framing_text',
+            field=models.TextField(help_text=b'Introductory text to display below question text, and above answer options and input fields belonging to this question (optional).', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='multiplechoicequestion',
+            name='framing_text',
+            field=models.TextField(help_text=b'Introductory text to display below question text, and above answer options and input fields belonging to this question (optional).', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='qualitativequestion',
+            name='framing_text',
+            field=models.TextField(help_text=b'Introductory text to display below question text, and above answer options and input fields belonging to this question (optional).', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='rankingquestion',
+            name='framing_text',
+            field=models.TextField(help_text=b'Introductory text to display below question text, and above answer options and input fields belonging to this question (optional).', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='likertscalequestion',
+            name='question_text',
+            field=models.TextField(help_text=b'Text to display above framing text, answer options (if any) and input fields.'),
+        ),
+        migrations.AlterField(
+            model_name='multiplechoicequestion',
+            name='question_text',
+            field=models.TextField(help_text=b'Text to display above framing text, answer options (if any) and input fields.'),
+        ),
+        migrations.AlterField(
+            model_name='qualitativequestion',
+            name='question_text',
+            field=models.TextField(help_text=b'Text to display above framing text, answer options (if any) and input fields.'),
+        ),
+        migrations.AlterField(
+            model_name='rankingquestion',
+            name='question_text',
+            field=models.TextField(help_text=b'Text to display above framing text, answer options (if any) and input fields.'),
+        ),
+    ]

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -57,7 +57,15 @@ class Section(OrderedModel):
         max_length=120,
         blank=True,
         null=True,
-        help_text='Text to display above questions belonging to this section (optional).',
+        help_text='Text to display at the top of this section (optional).',
+    )
+    intro_text = models.TextField(
+        blank=True,
+        null=True,
+        help_text=(
+            'Introductory text to display below section title '
+            'and above questions belonging to this section (optional).'
+        )
     )
 
     order_with_respect_to = 'lpd'

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -114,9 +114,9 @@ class Question(models.Model):
     def section_number(self):
         """
         Return string of the form 'X.Y'
-        where X represents `order` of parent section and Y represents `number` of this question.
+        where X represents 1-based `order` of parent section and Y represents `number` of this question.
         """
-        return '{section}.{number}'.format(section=self.section.order, number=self.number)
+        return '{section}.{number}'.format(section=self.section.order+1, number=self.number)
 
 
 class QualitativeQuestion(Question):

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -100,7 +100,15 @@ class Question(models.Model):
         help_text='Number of this question relative to parent section.'
     )
     question_text = models.TextField(
-        help_text='Text to display above answer options (if any) and input fields.',
+        help_text='Text to display above framing text, answer options (if any) and input fields.',
+    )
+    framing_text = models.TextField(
+        blank=True,
+        null=True,
+        help_text=(
+            'Introductory text to display below question text '
+            'and above answer options and input fields belonging to this question (optional).'
+        )
     )
     notes = models.TextField(
         blank=True,

--- a/lpd/templates/question.html
+++ b/lpd/templates/question.html
@@ -5,6 +5,10 @@
 
   <p><span class="question-number">{{ question.section_number }}</span> {{ question.question_text|render_custom_formatting }}</p>
 
+  {% if question.framing_text %}
+    <p class="framing-text">{{ question.framing_text }}</p>
+  {% endif %}
+
   {% if question.type == 'essay' %}
     <textarea class="answer-text">{% get_answer question learner %}</textarea>
   {% endif %}

--- a/lpd/templates/question.html
+++ b/lpd/templates/question.html
@@ -3,7 +3,7 @@
 
 <div class="question" data-question-id="{{ question.id }}" data-question-type="{{ question.type }}">
 
-  <p><span class="question-number">{{ question.section_number }}</span> {{ question.question_text }}</p>
+  <p><span class="question-number">{{ question.section_number }}</span> {{ question.question_text|render_custom_formatting }}</p>
 
   {% if question.type == 'essay' %}
     <textarea class="answer-text">{% get_answer question learner %}</textarea>

--- a/lpd/templates/question.html
+++ b/lpd/templates/question.html
@@ -3,10 +3,12 @@
 
 <div class="question" data-question-id="{{ question.id }}" data-question-type="{{ question.type }}">
 
-  <p><span class="question-number">{{ question.section_number }}</span> {{ question.question_text|render_custom_formatting }}</p>
+  <p class="question-text">
+    <span class="question-number">{{ question.section_number }}</span> {{ question.question_text|render_custom_formatting }}
+  </p>
 
   {% if question.framing_text %}
-    <p class="framing-text">{{ question.framing_text }}</p>
+    <p class="question-framing">{{ question.framing_text }}</p>
   {% endif %}
 
   {% if question.type == 'essay' %}

--- a/lpd/templates/question.html
+++ b/lpd/templates/question.html
@@ -3,7 +3,7 @@
 
 <div class="question" data-question-id="{{ question.id }}" data-question-type="{{ question.type }}">
 
-  <p>{{ question.section_number }} {{ question.question_text }}</p>
+  <p><span class="question-number">{{ question.section_number }}</span> {{ question.question_text }}</p>
 
   {% if question.type == 'essay' %}
     <textarea class="answer-text">{% get_answer question learner %}</textarea>
@@ -63,14 +63,7 @@
     <div class="ranking-options">
       {% for answer_option in question.get_answer_options %}
         <div class="ranking-option" data-answer-option-id="{{ answer_option.id }}">
-          {{ answer_option.option_text }}
           {% get_data answer_option learner as answer_option_data %}
-          {% if answer_option.allows_custom_input %}
-            <input type="text"
-                   name="{{ question.id }}-custom-input"
-                   class="custom-input"
-                   value="{{ answer_option_data.custom_input }}" />
-          {% endif %}
           {% for i in question.number_of_options_to_rank|range %}
             <label>
               <input type="radio"
@@ -81,24 +74,24 @@
               {{ i }}
             </label>
           {% endfor %}
-        </div>
-      {% endfor %}
-    </div>
-  {% endif %}
-
-  {% if question.type == 'likert' %}
-    <div class="likert-options">
-      <p>This is a {{ question.answer_option_range }}-point scale from {{ question.range_min_text }} to {{ question.range_max_text }}.</p>
-      {% for answer_option in question.get_answer_options %}
-        <div class="likert-option" data-answer-option-id="{{ answer_option.id }}">
           {{ answer_option.option_text }}
-          {% get_data answer_option learner as answer_option_data %}
           {% if answer_option.allows_custom_input %}
             <input type="text"
                    name="{{ question.id }}-custom-input"
                    class="custom-input"
                    value="{{ answer_option_data.custom_input }}" />
           {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if question.type == 'likert' %}
+    <p class="likert-info">This is a {{ question.answer_option_range }}-point scale from {{ question.range_min_text }} to {{ question.range_max_text }}.</p>
+    <div class="likert-options">
+      {% for answer_option in question.get_answer_options %}
+        <div class="likert-option" data-answer-option-id="{{ answer_option.id }}">
+          {% get_data answer_option learner as answer_option_data %}
           {% for i in question.answer_option_range|range %}
             <label>
               <input type="radio"
@@ -109,6 +102,13 @@
               {{ i }}
             </label>
           {% endfor %}
+          {{ answer_option.option_text }}
+          {% if answer_option.allows_custom_input %}
+            <input type="text"
+                   name="{{ question.id }}-custom-input"
+                   class="custom-input"
+                   value="{{ answer_option_data.custom_input }}" />
+          {% endif %}
         </div>
       {% endfor %}
     </div>

--- a/lpd/templates/section.html
+++ b/lpd/templates/section.html
@@ -7,7 +7,7 @@
   <h2 class="section-title" title="Click to expand/collapse this section">{{ section.title }}</h2>
 
   {% if section.intro_text %}
-    {{ section.intro_text|render_custom_formatting }}
+    <p class="section-intro">{{ section.intro_text|render_custom_formatting }}</p>
   {% endif %}
 
   <div class="section-questions">

--- a/lpd/templates/section.html
+++ b/lpd/templates/section.html
@@ -1,8 +1,14 @@
+{% load lpd_filters %}
+
 <form id="section-form" name="{{ form.form_name }}" action="#form" method="post" enctype="multipart/form-data">
 
   {% csrf_token %}
 
   <h2 class="section-title" title="Click to expand/collapse this section">{{ section.title }}</h2>
+
+  {% if section.intro_text %}
+    {{ section.intro_text|render_custom_formatting }}
+  {% endif %}
 
   <div class="section-questions">
     {% for profile_question in section.questions %}

--- a/lpd/templates/section.html
+++ b/lpd/templates/section.html
@@ -2,7 +2,7 @@
 
   {% csrf_token %}
 
-  <p class="section-title">{{ section.title }}</p>
+  <h2 class="section-title" title="Click to expand/collapse this section">{{ section.title }}</h2>
 
   <div class="section-questions">
     {% for profile_question in section.questions %}

--- a/lpd/templates/view.html
+++ b/lpd/templates/view.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   <div id="view-lpd">
-    <div class="lpd">{{ lpd }}</div>
+    <h1 class="lpd">{{ lpd }}</h1>
 
     {% for profile_section in lpd.sections.all %}
       {% with section_template="section.html" %}

--- a/lpd/templatetags/lpd_filters.py
+++ b/lpd/templatetags/lpd_filters.py
@@ -3,6 +3,8 @@ Custom template filters for Learner Profile Dashboard
 """
 
 from django import template
+from django.utils.safestring import mark_safe
+from markdown import markdown
 
 register = template.Library()
 
@@ -13,3 +15,13 @@ def option_range(count):
     Return range from 1 to `count`, including `count`.
     """
     return range(1, int(count) + 1)
+
+
+@register.filter()
+def render_custom_formatting(string):
+    """
+    Render custom formatting for `string`.
+
+    Supports both Markdown and HTML formatting directives.
+    """
+    return mark_safe(markdown(string))

--- a/lpd/templatetags/lpd_filters.py
+++ b/lpd/templatetags/lpd_filters.py
@@ -2,6 +2,8 @@
 Custom template filters for Learner Profile Dashboard
 """
 
+import re
+
 from django import template
 from django.utils.safestring import mark_safe
 from markdown import markdown
@@ -24,4 +26,8 @@ def render_custom_formatting(string):
 
     Supports both Markdown and HTML formatting directives.
     """
-    return mark_safe(markdown(string))
+    # Note that markdown callable wraps results in <p> tags, which is not what we want
+    # (it breaks the LPD's layout and makes it harder to target elements from CSS).
+    # So we remove these tags before returning the formatted string:
+    formatted_string = re.sub('</?p>', '', markdown(string))
+    return mark_safe(formatted_string)

--- a/lpd/tests/factories.py
+++ b/lpd/tests/factories.py
@@ -54,6 +54,7 @@ class SectionFactory(factory.DjangoModelFactory):
 
     lpd = factory.SubFactory(LearnerProfileDashboardFactory)
     title = factory.Sequence(u'Section {0}'.format)
+    order = factory.Sequence(lambda n: n)
 
 
 class QuestionFactory(factory.DjangoModelFactory):

--- a/lpd/tests/test_models.py
+++ b/lpd/tests/test_models.py
@@ -113,7 +113,7 @@ class QuestionTests(TestCase):
                 log.info('Creating %d questions using %s.', QUESTION_BATCH_SIZE, question_factory)
                 questions = question_factory.build_batch(QUESTION_BATCH_SIZE, section=section)
                 for question in questions:
-                    self.assertEqual(question.section_number, '{}.{}'.format(section.order, question.number))
+                    self.assertEqual(question.section_number, '{}.{}'.format(section.order+1, question.number))
 
 
 class QualitativeQuestionTests(TestCase):

--- a/lpd/tests/test_templatetags.py
+++ b/lpd/tests/test_templatetags.py
@@ -8,7 +8,7 @@ import ddt
 from django.test import TestCase
 
 from lpd.models import AnswerOption
-from lpd.templatetags.lpd_filters import option_range
+from lpd.templatetags.lpd_filters import option_range, render_custom_formatting
 from lpd.templatetags.lpd_tags import get_answer, get_data
 from lpd.tests.factories import QualitativeQuestionFactory, UserFactory
 from lpd.tests.test_models import QUANTITATIVE_QUESTION_FACTORIES
@@ -68,3 +68,18 @@ class TemplateFilterTests(TestCase):
         """
         range = option_range(count)  # pylint: disable=redefined-builtin
         self.assertEqual(range, expected_range)
+
+    @ddt.data(
+        ('This is not a test.', '<p>This is not a test.</p>'),
+        ('*This* is **not** a test.', '<p><em>This</em> is <strong>not</strong> a test.</p>'),
+        ('<em>This</em> is **not** a test.', '<p><em>This</em> is <strong>not</strong> a test.</p>'),
+        ('<strong>This</strong> is *not* a test.', '<p><strong>This</strong> is <em>not</em> a test.</p>'),
+    )
+    @ddt.unpack
+    def test_render_custom_formatting(self, string, expected_output):
+        """
+        Test that `render_custom_formatting` filter converts Markdown to HTML
+        and preserves custom HTML.
+        """
+        output = render_custom_formatting(string)
+        self.assertEqual(output, expected_output)

--- a/lpd/tests/test_templatetags.py
+++ b/lpd/tests/test_templatetags.py
@@ -70,10 +70,10 @@ class TemplateFilterTests(TestCase):
         self.assertEqual(range, expected_range)
 
     @ddt.data(
-        ('This is not a test.', '<p>This is not a test.</p>'),
-        ('*This* is **not** a test.', '<p><em>This</em> is <strong>not</strong> a test.</p>'),
-        ('<em>This</em> is **not** a test.', '<p><em>This</em> is <strong>not</strong> a test.</p>'),
-        ('<strong>This</strong> is *not* a test.', '<p><strong>This</strong> is <em>not</em> a test.</p>'),
+        ('This is not a test.', 'This is not a test.'),
+        ('*This* is **not** a test.', '<em>This</em> is <strong>not</strong> a test.'),
+        ('<em>This</em> is **not** a test.', '<em>This</em> is <strong>not</strong> a test.'),
+        ('<strong>This</strong> is *not* a test.', '<strong>This</strong> is <em>not</em> a test.'),
     )
     @ddt.unpack
     def test_render_custom_formatting(self, string, expected_output):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 django>=1.8,<1.9
 django-ordered-model==1.4.3
+Markdown==2.6.11
 nltk==3.2.5
 requests==2.11.1
 scikit-learn==0.19.1


### PR DESCRIPTION
cf. [OC-4362](https://tasks.opencraft.com/browse/OC-4362)

This PR changes the layout of the LPD according to client specifications, and introduces a number of additional improvements to make the LPD integrate more seamlessly with Open edX and look better overall.

**Screenshots**

*Top part of test LPD:*

![top-part-test](https://user-images.githubusercontent.com/961441/40607824-e0be6cde-6269-11e8-891d-ae5888c330ad.png)

*Bottom part of test LPD:*

![image](https://user-images.githubusercontent.com/961441/40607855-f801150e-6269-11e8-9440-81da662494b5.png)

**Test instructions**

1. Install requirements.
1. Run migrations.
1. Add some Markdown and custom HTML to the `question_text` of a question (bold/italics only):
    ```python
    from lpd.models import *
    q1 = QualitativeQuestion.objects.first()
    q1.question_text = 'Why <strong>does</strong> the *universe* exist?'
    q1.save()
    ```
1. Add a custom intro text to a section:
    ```python
    s1 = Section.objects.first()
    s1. intro_text = '**Lorem ipsum** dolor sit <em>amet</em>, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br /><br />Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br /><br />Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
    s1.save()
    ```
1. Add custom framing text to a question:
    ```python
    q1.framing_text = 'Lorem ipsum ...'
    s1.save()
    ```
1. Access the LPD in Studio/LMS (or directly) and observe that it looks much nicer than before 😁 
    - Question text of `q1` should render correctly.
    - Intro text of `s1` should be visible and render correctly.
    - Framing text of `q1` should be visible.

**Reviewers**

- [x] @tomaszgy 