### PR TITLE
Optimize processing of answer data, update logic for sending learner data to adaptive engine

### DIFF
--- a/app/static/js/lpd.js
+++ b/app/static/js/lpd.js
@@ -23,10 +23,11 @@ $(document).ready(function() {
     var renderChecked = function() {
         var optionInputs = $('.mc-option, .mr-option, .option-rank');
         optionInputs.each(function(i, optionInput) {
-            if ($(optionInput).attr('checked') === 'checked') {
-                $(optionInput).prop('checked', true);
+            var $optionInput = $(optionInput);
+            if ($optionInput.attr('checked') === 'checked') {
+                $optionInput.prop('checked', true);
             } else {
-                $(optionInput).prop('checked', false);
+                $optionInput.prop('checked', false);
             }
         });
     };
@@ -61,14 +62,15 @@ $(document).ready(function() {
             });
 
         $sameValueRanks.each(function(i, sameValueRank) {
-            if ($(sameValueRank).is(':checked')) {
-                $(sameValueRank).prop('checked', false);
+            var $sameValueRank = $(sameValueRank);
+            if ($sameValueRank.is(':checked')) {
+                $sameValueRank.prop('checked', false);
             }
         });
     };
 
     var collectAnswers = function($sectionForm) {
-        var $questions = $sectionForm.find('.question'),
+        var $questions = getUpdatedQuestions($sectionForm),
             qualitativeAnswers = [],
             quantitativeAnswers = [];
 
@@ -95,6 +97,12 @@ $(document).ready(function() {
             'qualitative_answers': JSON.stringify(qualitativeAnswers),
             'quantitative_answers': JSON.stringify(quantitativeAnswers)
         };
+    };
+
+    var getUpdatedQuestions = function($sectionForm) {
+        return $sectionForm.find('.question').filter(function() {
+            return $(this).data('answer-changed') === true;
+        });
     };
 
     var collectAnswerData = function($question, questionID) {
@@ -153,6 +161,13 @@ $(document).ready(function() {
         return $customInput;
     };
 
+    var resetQuestionState = function($sectionForm) {
+        var $questions = getUpdatedQuestions($sectionForm);
+        $questions.each(function(i, question) {
+            $(question).data('answer-changed', false);
+        });
+    };
+
 
     // Event handlers
 
@@ -165,6 +180,10 @@ $(document).ready(function() {
         $intro.toggle('slow');
         $questions.toggle('slow');
         $controls.toggle('slow');
+    });
+
+    $('.question').change(function(e) {
+        $(this).data('answer-changed', true);
     });
 
     $('.mr-option').click(function(e) {
@@ -190,6 +209,7 @@ $(document).ready(function() {
             success: function(data) {
                 console.log('SUCCESS');
                 console.log(data);
+                resetQuestionState($sectionForm);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.log('ERROR');

--- a/lpd/templates/question.html
+++ b/lpd/templates/question.html
@@ -1,7 +1,10 @@
 {% load lpd_filters %}
 {% load lpd_tags %}
 
-<div class="question" data-question-id="{{ question.id }}" data-question-type="{{ question.type }}">
+<div class="question"
+     data-question-id="{{ question.id }}"
+     data-question-type="{{ question.type }}"
+     data-answer-changed="false">
 
   <p class="question-text">
     <span class="question-number">{{ question.section_number }}</span> {{ question.question_text|render_custom_formatting }}


### PR DESCRIPTION
cf. [OC-4548](https://tasks.opencraft.com/browse/OC-4548)

This PR updates the logic for sending learner data to the adaptive engine based on some recent changes to the endpoint specification, and optimizes the processing of answer data. In particular, we now:

- Avoid sending answer data to the server if it wasn't changed since the learner last loaded the page or successfully submitted their answers for a given section.
- Run group membership calculation iff learner changed their answer(s) to one or more qualitative questions that belong to the section being submitted, and that are configured to influence recommendations.
- Avoid sending learner data to the adaptive engine if the learner did not change any of their answers.

<!--
**Relevant commits**

This PR builds on #9; only the following commits are relevant:

- 9c96345764e5dff0b1b545d1bfe39703546535ed: Update logic for sending learner data to adaptive engine to conform to new endpoint specification.
- 122bf33f86c52c367d2cf276e1bf7e1737ff6aff: Optimize processing of answer data.
- 6d01702a9760b74fd357c38e4a2ed3b01b5c318d: Skip group membership calculation if learner did not change answers to any qualitative questions that are configured to influence recommendations.
-->

**Test instructions**

*Setting up*

1. Make sure you have the setup from the first two steps for testing https://github.com/open-craft/learner-profile-dashboard/pull/8 in place.
1. Temporarily insert
    ```python
    print(payload)
    ```
    before the last line of `lpd/client.py`. This will allow you to inspect the data that the LPD sends to the adaptive engine later on.
1. Temporarily make
    ```js
    resetQuestionState($sectionForm);
    ```
    the last line of the [`error` handler](https://github.com/open-craft/learner-profile-dashboard/blob/optimize/app/static/js/lpd.js#L214-L218) for submitting AJAX requests to the server. This is necessary because we don't have the necessary credentials to connect the LPD to an adaptive engine deployment yet, which means that submitting answer data will fail when trying to send data to the adaptive engine. However, in these cases we still want to be able to test the new behavior of the [`success` handler](https://github.com/open-craft/learner-profile-dashboard/blob/optimize/app/static/js/lpd.js#L209-L213), so we need to replicate it in the `error` handler.

*Testing*

1. Access the LPD in Studio/LMS, via a unit that contains it.
1. Provide **no** answers to LPD questions and click "Submit your answers".
1. Check the development server's output for a payload to send to the adaptive engine. Since you didn't update any answers in the previous step, you should not see one.
1. Provide answers to one or more qualitative questions that **do not** influence group membership and click "Submit your answers".
1. Check the development server's output for a payload to send to the adaptive engine. Since you didn't update any answers that influence group membership in the previous step, you should not see one.
1. Provide answers to one or more qualitative questions that **do** influence group membership and click "Submit your answers".
1. Check the development server's output. It should contain a list of entries that corresponds to the set of knowledge components representing groups (i.e., it should contain an entry for each group from `GROUP_KCS`). Each entry should match the [expected format](https://github.com/open-craft/learner-profile-dashboard/blob/optimize/lpd/client.py#L50-L59); the information associated with the `'learner'` key should be identical across entries:
    ```python
            {
                'knowledge_component': {
                    'kc_id': '<kc_id_n>'
                },
                'learner': {
                    'tool_consumer_instance_guid': settings.OPENEDX_INSTANCE_DOMAIN,
                    'user_id': '<lti_user_id>'
                },
                'value': <value_n>
            },
    ```
1. Provide answers to one or more quantitative questions whose answer options **do not** influence recommendations and click "Submit your answers".
1. Check the development server's output for a payload to send to the adaptive engine. Since you didn't update any answers whose answer options influence recommendations in the previous step, you should not see one.
1. Provide answers to one or more quantitative questions whose answer options **do** influence recommendations and click "Submit your answers".
1. Check the development server's output. It should contain entries for all answer options that are configured to influence recommendations, and that belong to the question(s) whose answers you changed in the previous step.
1. Lastly, if you provide answers to relevant qualitative *and* quantitative questions, the payload should contain an appropriate combination of entries (i.e., entries for each group from `GROUP_KCS` as well as entries for all answer options that are configured to influence recommendations, and that belong to the question(s) whose answers you changed).

**Reviewers**

- [x] @tomaszgy 