### PR TITLE
List fallback options last for quantitative questions

### DIFF
--- a/lpd/client.py
+++ b/lpd/client.py
@@ -40,7 +40,7 @@ class AdaptiveEngineAPIClient(object):
     @classmethod
     def send_learner_data(cls, user, scores):
         """
-        Sends POST request with up-to-date learner data for `user` to adaptive engine.
+        Sends PUT request with up-to-date learner data for `user` to adaptive engine.
 
         Endpoint: /engine/api/mastery/bulk_update
 

--- a/lpd/migrations/0010_introduce_fallback_options.py
+++ b/lpd/migrations/0010_introduce_fallback_options.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lpd', '0009_likert_scale_labels'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='answeroption',
+            name='fallback_option',
+            field=models.BooleanField(default=False, help_text=b'Whether this is a catch-all option that learners would choose if none of the other options apply to them.'),
+        ),
+    ]


### PR DESCRIPTION
cf. [OC-4613](https://tasks.opencraft.com/browse/OC-4613)

This PR introduces the notion of *fallback options* for quantitative questions. A fallback option is a catch-all option that learners would choose if none of the other options apply to them (such as "Don't know", or "Other:"). The PR also makes sure that fallback options are always displayed last, in reverse alphabetical order, regardless of whether a question is configured to display answer options in random order or not.

**Test instructions**

1. Run migrations.
1. Make sure your LPD has at least one quantitative question with `randomize_options` set to `True` and one quantitative question with `randomize_options` set to `False`.
1. For each of these questions, set `fallback_option` to `True` for two of its answer options and persist the change to the DB. (Ideally, each question should have four or more answer options associated with it.)
1. Access the LPD and observe that:
    - Regular options are listed at the top, in random or alphabetical order (depending on the value of `randomize_options`).
    - Fallback options are listed at the bottom, in reverse alphabetical order.

**Reviewers**

- [ ] @tomaszgy 