### PR TITLE
Add support for referencing/embedding specific questions

### DIFF
--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -58,15 +58,15 @@ body {
     font-size: 0.95rem;
 }
 
-.section-intro, .section-questions, .section-controls {
+.section-intro, .section-questions, .section-controls, .question-controls {
     padding-left: 0.4rem;
 }
 
-.section-questions, .section-controls, .question {
+.section-questions, .section-controls, .question-controls, .question {
     margin-bottom: 4rem;
 }
 
-.question-number, .ranking-option > label:last-of-type, .section-submit {
+.question-number, .ranking-option > label:last-of-type, .section-submit, .question-submit {
     margin-right: 1.4rem;
 }
 
@@ -119,7 +119,7 @@ body {
     margin-left: 0.6rem;
 }
 
-.section-submit {
+.section-submit, .question-submit {
     box-shadow: none;
     border-color: #0075b4;
     border-style: solid;
@@ -133,6 +133,6 @@ body {
     cursor: pointer;
 }
 
-.section-submit:hover {
+.section-submit:hover, .question-submit:hover {
 	background-color: #065683;
 }

--- a/app/static/js/lpd.js
+++ b/app/static/js/lpd.js
@@ -57,11 +57,11 @@ $(document).ready(function() {
         $('.submission-info').each(function(i, submissionInfo) {
             var $submissionInfo = $(submissionInfo),
                 lastUpdate = $submissionInfo.data('last-update'),
-                $sectionForm = $submissionInfo.parents('form'),
+                $submissionForm = $submissionInfo.parents('form'),
                 data = {
                     'last_update': lastUpdate
                 };
-            updateSubmissionInfo($sectionForm, data);
+            updateSubmissionInfo($submissionForm, data);
         });
     };
 
@@ -81,8 +81,8 @@ $(document).ready(function() {
         });
     };
 
-    var collectAnswers = function($sectionForm) {
-        var $questions = getUpdatedQuestions($sectionForm),
+    var collectAnswers = function($submissionForm) {
+        var $questions = getUpdatedQuestions($submissionForm),
             qualitativeAnswers = [],
             quantitativeAnswers = [];
 
@@ -111,8 +111,8 @@ $(document).ready(function() {
         };
     };
 
-    var getUpdatedQuestions = function($sectionForm) {
-        return $sectionForm.find('.question').filter(function() {
+    var getUpdatedQuestions = function($submissionForm) {
+        return $submissionForm.find('.question').filter(function() {
             return $(this).data('answer-changed') === true;
         });
     };
@@ -173,15 +173,15 @@ $(document).ready(function() {
         return $customInput;
     };
 
-    var resetQuestionState = function($sectionForm) {
-        var $questions = getUpdatedQuestions($sectionForm);
+    var resetQuestionState = function($submissionForm) {
+        var $questions = getUpdatedQuestions($submissionForm);
         $questions.each(function(i, question) {
             $(question).data('answer-changed', false);
         });
     };
 
-    var updateSubmissionInfo = function($sectionForm, data) {
-        var $submissionInfo = $sectionForm.find('.submission-info'),
+    var updateSubmissionInfo = function($submissionForm, data) {
+        var $submissionInfo = $submissionForm.find('.submission-info'),
             lastUpdate = data.last_update;
         $submissionInfo.text(formatLastUpdate(lastUpdate));
     };
@@ -200,22 +200,6 @@ $(document).ready(function() {
     };
 
 
-    // Event handlers
-
-    $('.section-title').click(function(e) {
-        var $sectionForm = $(this).parent('form'),
-            $sectionCollapse = $sectionForm.find('.section-collapse'),
-            $intro = $sectionForm.children('.section-intro'),
-            $questions = $sectionForm.children('.section-questions'),
-            $controls = $sectionForm.children('.section-controls');
-
-        $sectionCollapse.toggleClass('expanded');
-        $sectionCollapse.toggleClass('collapsed');
-        $intro.toggle('slow');
-        $questions.toggle('slow');
-        $controls.toggle('slow');
-    });
-
     $('.question').change(function(e) {
         $(this).data('answer-changed', true);
     });
@@ -229,25 +213,25 @@ $(document).ready(function() {
         uncheckSameValueRanks(this);
     });
 
-    $('.section-submit').click(function(e) {
+    $('.section-submit, .question-submit').click(function(e) {
         e.preventDefault();
         console.log('Submitting answers ...');
 
-        var $sectionForm = $(this).parents('form'),
-            sectionID = $sectionForm.data('section-id'),
-            answers = collectAnswers($sectionForm);
+        var $submissionForm = $(this).parents('form'),
+            sectionID = $submissionForm.data('section-id'),
+            answers = collectAnswers($submissionForm);
 
         answers['section_id'] = sectionID;
 
         $.ajax({
-            url: 'submit',
+            url: '/lpd/submit',
             type: 'POST',
             data: answers,
             success: function(data) {
                 console.log('SUCCESS');
                 console.log(data);
-                resetQuestionState($sectionForm);
-                updateSubmissionInfo($sectionForm, data);
+                resetQuestionState($submissionForm);
+                updateSubmissionInfo($submissionForm, data);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.log('ERROR');

--- a/app/static/js/section.js
+++ b/app/static/js/section.js
@@ -1,0 +1,23 @@
+/*
+ * JavaScript for Learner Profile Dashboard (sections)
+ */
+
+$(document).ready(function() {
+
+    // Event handlers
+
+    $('.section-title').click(function(e) {
+        var $sectionForm = $(this).parent('form'),
+            $sectionCollapse = $sectionForm.find('.section-collapse'),
+            $intro = $sectionForm.children('.section-intro'),
+            $questions = $sectionForm.children('.section-questions'),
+            $controls = $sectionForm.children('.section-controls');
+
+        $sectionCollapse.toggleClass('expanded');
+        $sectionCollapse.toggleClass('collapsed');
+        $intro.toggle('slow');
+        $questions.toggle('slow');
+        $controls.toggle('slow');
+    });
+
+});

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -27,7 +27,7 @@ class LearnerProfileDashboard(models.Model):
     modified_at = models.DateTimeField(auto_now=True, editable=False)
 
     def __unicode__(self):
-        return self.name
+        return 'LPD {id}: {name}'.format(id=self.id, name=self.name)
 
     def __str__(self):
         return unicode(self).encode('utf-8')
@@ -78,7 +78,9 @@ class Section(OrderedModel):
         pass
 
     def __unicode__(self):
-        return 'Section {id}: {title}'.format(id=self.id, title=self.title or '<title not set>')
+        return '{lpd} > Section {id}: {title}'.format(
+            lpd=str(self.lpd), id=self.id, title=self.title or '<title not set>'
+        )
 
     @property
     def questions(self):
@@ -172,7 +174,9 @@ class QualitativeQuestion(Question):
     )
 
     def __unicode__(self):
-        return 'QualitativeQuestion {id}: {text}'.format(id=self.id, text=self.question_text)
+        return '{section} > QualitativeQuestion {id}: {text}'.format(
+            section=str(self.section), id=self.id, text=self.question_text
+        )
 
     @property
     def type(self):
@@ -331,7 +335,9 @@ class MultipleChoiceQuestion(QuantitativeQuestion):
     )
 
     def __unicode__(self):
-        return 'MultipleChoiceQuestion {id}: {text}'.format(id=self.id, text=self.question_text)
+        return '{section} > MultipleChoiceQuestion {id}: {text}'.format(
+            section=str(self.section), id=self.id, text=self.question_text
+        )
 
     @property
     def type(self):
@@ -381,7 +387,9 @@ class RankingQuestion(QuantitativeQuestion):
     )
 
     def __unicode__(self):
-        return 'RankingQuestion {id}: {text}'.format(id=self.id, text=self.question_text)
+        return '{section} > RankingQuestion {id}: {text}'.format(
+            section=str(self.section), id=self.id, text=self.question_text
+        )
 
     @property
     def type(self):
@@ -457,7 +465,9 @@ class LikertScaleQuestion(QuantitativeQuestion):
     )
 
     def __unicode__(self):
-        return 'LikertScaleQuestion {id}: {text}'.format(id=self.id, text=self.question_text)
+        return '{section} > LikertScaleQuestion {id}: {text}'.format(
+            section=str(self.section), id=self.id, text=self.question_text
+        )
 
     @property
     def type(self):
@@ -529,7 +539,9 @@ class AnswerOption(models.Model):
         ordering = ["-option_text"]
 
     def __unicode__(self):
-        return 'AnswerOption {id}: {text}'.format(id=self.id, text=self.option_text)
+        return '{question} > AnswerOption {id}: {text}'.format(
+            question=str(self.content_object), id=self.id, text=self.option_text
+        )
 
     def get_data(self, learner):
         """
@@ -627,7 +639,17 @@ class KnowledgeComponent(models.Model):
     )
 
     def __unicode__(self):
-        return 'KnowledgeComponent {id}: {kc_id}, {kc_name}'.format(id=self.id, kc_id=self.kc_id, kc_name=self.kc_name)
+        kc_info = 'KnowledgeComponent {id}: {kc_id}, {kc_name}'.format(
+            id=self.id, kc_id=self.kc_id, kc_name=self.kc_name
+        )
+        try:
+            answer_option = str(self.answer_option)
+        except AnswerOption.DoesNotExist:
+            return kc_info
+        else:
+            return '{kc_info} (associated with {answer_option})'.format(
+                kc_info=kc_info, answer_option=answer_option
+            )
 
 
 class Score(models.Model):

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -5,7 +5,6 @@ Models for Learner Profile Dashboard
 import itertools
 import re
 
-from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -37,15 +36,6 @@ class LearnerProfileDashboard(models.Model):
         Return URL for viewing details about a specific Learner Profile Dashboard instance.
         """
         return reverse('lpd:view', kwargs=dict(pk=self.id))
-
-
-class LearnerProfileDashboardForm(forms.ModelForm):
-    """
-    Form for creating an instance of the Learner Profile Dashboard.
-    """
-    class Meta:
-        model = LearnerProfileDashboard
-        fields = ['name']
 
 
 class Section(OrderedModel):

--- a/lpd/models.py
+++ b/lpd/models.py
@@ -178,6 +178,12 @@ class QualitativeQuestion(Question):
             section=str(self.section), id=self.id, text=self.question_text
         )
 
+    def get_absolute_url(self):
+        """
+        Return URL for viewing details about a specific qualitative question.
+        """
+        return reverse('lpd:qualitative-question', kwargs=dict(pk=self.id))
+
     @property
     def type(self):
         """
@@ -339,6 +345,12 @@ class MultipleChoiceQuestion(QuantitativeQuestion):
             section=str(self.section), id=self.id, text=self.question_text
         )
 
+    def get_absolute_url(self):
+        """
+        Return URL for viewing details about a specific multiple choice question.
+        """
+        return reverse('lpd:multiple-choice-question', kwargs=dict(pk=self.id))
+
     @property
     def type(self):
         """
@@ -390,6 +402,12 @@ class RankingQuestion(QuantitativeQuestion):
         return '{section} > RankingQuestion {id}: {text}'.format(
             section=str(self.section), id=self.id, text=self.question_text
         )
+
+    def get_absolute_url(self):
+        """
+        Return URL for viewing details about a specific ranking question.
+        """
+        return reverse('lpd:ranking-question', kwargs=dict(pk=self.id))
 
     @property
     def type(self):
@@ -468,6 +486,12 @@ class LikertScaleQuestion(QuantitativeQuestion):
         return '{section} > LikertScaleQuestion {id}: {text}'.format(
             section=str(self.section), id=self.id, text=self.question_text
         )
+
+    def get_absolute_url(self):
+        """
+        Return URL for viewing details about a specific Likert scale question.
+        """
+        return reverse('lpd:likert-scale-question', kwargs=dict(pk=self.id))
 
     @property
     def type(self):

--- a/lpd/templates/lpd-view.html
+++ b/lpd/templates/lpd-view.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 
+{% load staticfiles %}
+
+{% block js %}
+  {{ block.super }}
+  <script src="{% static "js/section.js" %}"></script>
+{% endblock js %}
+
 {% block content %}
   <div id="view-lpd">
     <h1 class="lpd">{{ lpd.name }}</h1>

--- a/lpd/templates/lpd.html
+++ b/lpd/templates/lpd.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   <div id="view-lpd">
-    <h1 class="lpd">{{ lpd }}</h1>
+    <h1 class="lpd">{{ lpd.name }}</h1>
 
     {% for profile_section in lpd.sections.all %}
       {% with section_template="section.html" %}

--- a/lpd/templates/question-view.html
+++ b/lpd/templates/question-view.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% load lpd_tags %}
+
+{% block content %}
+  <div id="view-question">
+    <form id="question-form"
+          action="#form"
+          method="post"
+          enctype="multipart/form-data"
+          data-section-id="{{ question.section.id }}">
+
+      {% csrf_token %}
+
+      {% with question_template="question.html" %}
+        {% include question_template with question=question %}
+      {% endwith %}
+
+      <div class="question-controls">
+        <p class="submit-instructions">
+          Don’t forget to submit! Your answer will not be saved until you click the submit button below.
+        </p>
+        <button type="submit" class="question-submit">
+          Submit your answer
+        </button>
+        {% get_last_update question.section learner as last_update %}
+        <span class="submission-info" data-last-update="{{ last_update }}"></span>
+      </div>
+
+    </form>
+  </div>
+{% endblock content %}

--- a/lpd/templates/section.html
+++ b/lpd/templates/section.html
@@ -2,7 +2,6 @@
 {% load lpd_tags %}
 
 <form id="section-form"
-      name="{{ form.form_name }}"
       action="#form"
       method="post"
       enctype="multipart/form-data"

--- a/lpd/tests/factories.py
+++ b/lpd/tests/factories.py
@@ -98,7 +98,7 @@ class LikertScaleQuestionFactory(QuestionFactory):
     class Meta:
         model = LikertScaleQuestion
 
-    answer_option_range = random.randint(1, 10)
+    answer_option_range = random.choice(['value', 'agreement'])
 
 
 class QualitativeAnswerFactory(factory.DjangoModelFactory):

--- a/lpd/urls.py
+++ b/lpd/urls.py
@@ -15,4 +15,24 @@ app_name = 'lpd'
 urlpatterns = [
     url(r'^submit$', login_required(views.LPDSubmitView.as_view()), name='submit'),
     url(r'^(?P<pk>\d+)$', login_required(views.LPDView.as_view()), name='view'),
+    url(
+        r'^q_qualitative/(?P<pk>\d+)$',
+        login_required(views.QualitativeQuestionView.as_view()),
+        name='qualitative-question'
+    ),
+    url(
+        r'^q_mcq/(?P<pk>\d+)$',
+        login_required(views.MultipleChoiceQuestionView.as_view()),
+        name='multiple-choice-question'
+    ),
+    url(
+        r'^q_ranking/(?P<pk>\d+)$',
+        login_required(views.RankingQuestionView.as_view()),
+        name='ranking-question'
+    ),
+    url(
+        r'^q_likert/(?P<pk>\d+)$',
+        login_required(views.LikertScaleQuestionView.as_view()),
+        name='likert-scale-question'
+    ),
 ]

--- a/lpd/views.py
+++ b/lpd/views.py
@@ -19,10 +19,13 @@ from lpd.models import (
     AnswerOption,
     LearnerProfileDashboard,
     LearnerProfileDashboardForm,
+    LikertScaleQuestion,
+    MultipleChoiceQuestion,
     QualitativeAnswer,
     QualitativeQuestion,
     QuantitativeAnswer,
     QuantitativeQuestion,
+    RankingQuestion,
     Score,
     Section,
     Submission,
@@ -42,7 +45,7 @@ class LPDView(DetailView):
     Display specific LPD to learner.
     """
     model = LearnerProfileDashboard
-    template_name = 'lpd.html'
+    template_name = 'lpd-view.html'
 
     def get_context_data(self, **kwargs):
         """
@@ -55,6 +58,53 @@ class LPDView(DetailView):
         context['learner'] = learner
         context['lpd'] = lpd
         return context
+
+
+class QuestionView(DetailView):
+    """
+    Base class defining common logic for displaying specific question to learner.
+    """
+    template_name = 'question-view.html'
+
+    def get_context_data(self, **kwargs):
+        """
+        Collect necessary information for displaying question.
+        """
+        context = super(QuestionView, self).get_context_data(**kwargs)
+        learner = User.objects.get(username=self.request.user.username)
+        question_pk = self.kwargs.get('pk')
+        question = self.model.objects.get(pk=question_pk)
+        context['learner'] = learner
+        context['question'] = question
+        return context
+
+
+class QualitativeQuestionView(QuestionView):
+    """
+    Display specific qualitative question to learner.
+    """
+    model = QualitativeQuestion
+
+
+class MultipleChoiceQuestionView(QuestionView):
+    """
+    Display specific multiple choice question to learner.
+    """
+    model = MultipleChoiceQuestion
+
+
+class RankingQuestionView(QuestionView):
+    """
+    Display specific ranking question to learner.
+    """
+    model = RankingQuestion
+
+
+class LikertScaleQuestionView(QuestionView):
+    """
+    Display specific Likert scale question to learner.
+    """
+    model = LikertScaleQuestion
 
 
 class LPDSubmitView(View):

--- a/lpd/views.py
+++ b/lpd/views.py
@@ -18,7 +18,6 @@ from lpd.client import AdaptiveEngineAPIClient
 from lpd.models import (
     AnswerOption,
     LearnerProfileDashboard,
-    LearnerProfileDashboardForm,
     LikertScaleQuestion,
     MultipleChoiceQuestion,
     QualitativeAnswer,
@@ -357,11 +356,3 @@ class LPDSubmitView(View):
         )
         log.info('Date and time of latest submission: %s.', submission.updated.strftime('%m/%d/%Y at %I:%M %p (UTC)'))
         return get_last_update(section, user)
-
-
-class LearnerProfileDashboardViewMixin(object):
-    """
-    Mixin for CRUD views for Learner Profile Dashboard.
-    """
-    model = LearnerProfileDashboard
-    form_class = LearnerProfileDashboardForm


### PR DESCRIPTION
Cf. [SE-953](https://tasks.opencraft.com/browse/SE-953)

This PR makes it possible to embed specific questions from the LPD into a course. (Up until now, it was only possible to embed full LPDs.) Course authors can target a specific question to embed by providing its ID and type via the "Custom Parameters" setting of the LTI Component that's supposed to embed the question.

**Screenshots**

- Setting "Custom Parameters" to specify target question in Studio: ![studio-question-component](https://user-images.githubusercontent.com/961441/56202968-83fdc600-6044-11e9-9cf3-c11cbf6b299a.png)

- A single question embedded into a course: ![lms-question-component](https://user-images.githubusercontent.com/961441/56202975-86f8b680-6044-11e9-86a5-113e2ca90dab.png)

**Test instructions**

1. Create an account on [HGSE stage](https://hgse-stage.opencraft.hosting/) and enroll into the [demo course](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about).

1. Navigate to [this unit](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@76a8b14f7fd44521816d278c78e777c5).

    - Verify that the questions embedded there render correctly: They should include a "Submit your answer" button and a submission timestamp next to it (which will initially say "Not yet submitted").

    - Answer each question and click "Submit your answer".

        - Observe that the submission timestamp updates to display the time and date of your most recent submission. Make a note of the submission timestamps for both questions.

        - Observe that the answers you provided remain visible.

1. In a new browser tab, navigate to [this unit](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@45c7cedb4bfe46f4a68c78787151cfb5), which contains the LPD to which the questions from the unit you were working with in the previous step belong.

    - Locate the questions (using "Find in page" functionality of your browser) one by one.

    - For each question, observe that the answer displayed matches the answer you provided in the previous step.

    - For each question, scroll down to the end of the parent section (i.e., to the closest "Submit your answers" button that you can find below the question). Observe that the submission timestamp of the parent section matches the submission timestamp of the question that you noted down earlier. (If both questions belong to the same section, the submission timestamp of the section should match the submission timestamp of the question that you submitted last.)

    - For each question, alter your answers slightly and submit them by clicking the "Submit your answers" button of the parent section(s). Make a note of the submission timestamp(s).

1. Switch back to the browser tab displaying individual questions and refresh the page.

    - Observe that answer data updates to match the most recent answers you provided in the previous step.

    - Observe that the submission timestamps update match the submission timestamp(s) from the parent section(s).

1. Repeat the steps above for the following units containing other question types:

    - [Multiple Choice Questions](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@c05f45fcec50466e87ed86f0687349a5)

    - [Ranking Question](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4b9156e5a4304a819bc189ec8f69c90e)

    - [Likert Scale Questions](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@4d0e01b1ee5c4f90bc3549d0975eed97)

    *Note that some questions are set up to display answer options in random order, so answers might not look the same at a glance even though they actually match.*

**Reviewers**

- [x] @pkulkark