### PR TITLE
Display information about profile and section-level completion

### DIFF
--- a/app/static/css/lpd.css
+++ b/app/static/css/lpd.css
@@ -50,6 +50,10 @@ body {
     font-size: 0.85rem;
 }
 
+.section-completeness {
+    float: right;
+}
+
 .section-intro, .submit-instructions {
     margin-bottom: 1.6rem;
 }

--- a/app/static/js/lpd.js
+++ b/app/static/js/lpd.js
@@ -59,7 +59,9 @@ $(document).ready(function() {
                 lastUpdate = $submissionInfo.data('last-update'),
                 $submissionForm = $submissionInfo.parents('form'),
                 data = {
-                    'last_update': lastUpdate
+                    'last_update': {
+                        'timestamp': lastUpdate
+                    }
                 };
             updateSubmissionInfo($submissionForm, data);
         });
@@ -182,7 +184,7 @@ $(document).ready(function() {
 
     var updateSubmissionInfo = function($submissionForm, data) {
         var $submissionInfo = $submissionForm.find('.submission-info'),
-            lastUpdate = data.last_update;
+            lastUpdate = data.last_update.timestamp;
         $submissionInfo.text(formatLastUpdate(lastUpdate));
     };
 
@@ -199,6 +201,17 @@ $(document).ready(function() {
         return 'Submitted on ' + date + ' at ' + time;
     };
 
+    var updateCompletionInfo = function($submissionForm, data) {
+        var $parentLPD = $submissionForm.parents('#view-lpd'),
+            $profileCompleteness = $parentLPD.find('.profile-completeness'),
+            $sectionCompleteness = $submissionForm.find('.section-completeness');
+
+        $profileCompleteness.text('(' + data.last_update.completion_percentages.profile + ' complete)');
+        $sectionCompleteness.text(data.last_update.completion_percentages.section + ' complete');
+    };
+
+
+    // Event handlers
 
     $('.question').change(function(e) {
         $(this).data('answer-changed', true);
@@ -232,6 +245,7 @@ $(document).ready(function() {
                 console.log(data);
                 resetQuestionState($submissionForm);
                 updateSubmissionInfo($submissionForm, data);
+                updateCompletionInfo($submissionForm, data);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.log('ERROR');

--- a/lpd/templates/lpd-view.html
+++ b/lpd/templates/lpd-view.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load staticfiles %}
+{% load lpd_tags %}
 
 {% block js %}
   {{ block.super }}
@@ -9,7 +10,10 @@
 
 {% block content %}
   <div id="view-lpd">
-    <h1 class="lpd">{{ lpd.name }}</h1>
+    <h1 class="lpd">
+      {% get_percent_complete lpd learner as completion_percentage %}
+      {{ lpd.name }} <span class="profile-completeness">({{ completion_percentage }} complete)</span>
+    </h1>
 
     {% for profile_section in lpd.sections.all %}
       {% with section_template="section.html" %}

--- a/lpd/templates/section.html
+++ b/lpd/templates/section.html
@@ -11,6 +11,8 @@
 
   <h2 class="section-title" title="Click to expand/collapse this section">
     <i class="fas fa-caret-right section-collapse expanded"></i> {{ section.title }} <span class="section-instructions">(click to expand and collapse)</span>
+    {% get_percent_complete section learner as completion_percentage %}
+    <span class="section-completeness">{{ completion_percentage }} complete</span>
   </h2>
 
   {% if section.intro_text %}

--- a/lpd/templatetags/lpd_tags.py
+++ b/lpd/templatetags/lpd_tags.py
@@ -12,6 +12,18 @@ register = template.Library()
 
 
 @register.simple_tag
+def get_percent_complete(component, learner):
+    """
+    Return string representing completion status of `learner` for `component`.
+
+    `component` should be an instance of `LearnerProfileDashboard` or `Section`.
+    """
+    return '{percent_complete:.0f}%'.format(
+        percent_complete=component.get_percent_complete(learner)
+    )
+
+
+@register.simple_tag
 def get_last_update(section, learner):
     """
     Return timestamp corresponding to date and time at which `learner` last submitted `section`.


### PR DESCRIPTION
Cf. [SE-952](https://tasks.opencraft.com/browse/SE-952)

This PR adds functionality for displaying profile and section-level completion (in the form of percentages) on full-LPD embeds. It also adds logic for automatically updating completion information when a learner successfully submits answers belonging to a specific section of an LPD.

### Definition of completeness

#### Profile

A learner’s profile is *complete* if and only if they submitted an answer to each available question. What constitutes an answer differs based on question type (cf. below).

A learner’s profile is *partially complete* if they submitted answers for less than 100% of all questions belonging to a given LPD instance.

If a profile does not have any sections associated with it, it is considered 0% complete by default.

#### Section

Similarly, a section is complete if and only if a learner submitted an answer to each question belonging to that section. It is partially complete if the learner submitted answers for less than 100% of all questions belonging to it.

If a section does not have any questions associated with it, it is considered 0% complete by default.

### Screenshots

Profile and section-level completeness:

![lpd-completion-percentages](https://user-images.githubusercontent.com/961441/56671406-e09c5900-66b4-11e9-9d13-6a00141c0c44.png)

### Test instructions

1. If you haven't already, create an account on [HGSE stage](https://hgse-stage.opencraft.hosting/) and enroll in the [demo course](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about).

1. Navigate to [this unit](https://hgse-stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@45c7cedb4bfe46f4a68c78787151cfb5).

1. For each section:

    1. Answer some questions and click "Submit your answers".

    1. Verify that the completion percentage for the section as well as the completion percentage for the LPD as a whole (displayed at the very top) update to reflect the changes that you made.

        - Note that if you only *change* an existing answer and click "Submit your answers" without providing any *additional* answers, the completion percentages shouldn't change.

        - If you're not sure about a specific update to profile and section-level completion percentages, have a look at relevant information about the LPD's criteria for considering a question answered. These criteria differ based on question type:

            - [Qualitative questions](https://github.com/open-craft/learner-profile-dashboard/blob/profile-completion/lpd/models.py#L277)
            - [Multiple choice questions](https://github.com/open-craft/learner-profile-dashboard/blob/profile-completion/lpd/models.py#L439-L440)
            - [Ranking questions](https://github.com/open-craft/learner-profile-dashboard/blob/profile-completion/lpd/models.py#L525-L537)
            - [Likert scale questions](https://github.com/open-craft/learner-profile-dashboard/blob/profile-completion/lpd/models.py#L595-L596)

    1. Reload the page.

    1. Verify that the changes to completion percentages that you observed in the previous step persist.

    1. Answer some additional questions and reload the page *without* clicking "Submit your answers".

    1. Verify that completion percentages reset to values that you observed previously.

### Author notes

In terms of UX, an alternative to updating completion information after successfully submitting answers via the "Submit your answers" button would be to update completion information as a learner moves from question to question, adding/updating their answers along the way. However, this is not an option for the current LPD implementation: Answer data is recorded/updated in the DB only after a learner explicitly indicates that they want to submit their answers for a section (by clicking the corresponding "Submit your answers" button). (In other words, no changes are made to answer data stored in the DB as the learner moves from question to question.) If they navigate away without clicking "Submit your answers", the current set of answers from the learner that is stored in the DB doesn't change, and neither do the learner's completion statistics for individual sections and the LPD as a whole. So updating completion information as the learner moves from question to question wouldn't make sense -- it wouldn't accurately reflect the current state of the DB, and could potentially confuse the learner since the changes to their completion statistics wouldn't necessarily be permanent. (They'd reset to previous values if the learner came back to their learner profile after forgetting to submit pending changes to their answers.)

### Reviewers

- [x] @DevanR