### PR TITLE
Fix iframe fix

### DIFF
--- a/iframe/templates/cookie_warning.html
+++ b/iframe/templates/cookie_warning.html
@@ -19,7 +19,7 @@
   </p>
 
   <div id="cookie_link" style="display:block">
-    <a target=_blank href="javascript:popup();">Enable loading of missing content</a><br>
+    <a target="_blank" href="javascript:popup();">Enable loading of missing content</a><br>
   </div>
 
   <div id="refresh_message" style="display:none">
@@ -30,7 +30,7 @@
 
   <script type="text/javascript">
     var popup = function() {
-        var helperWindow = window.open("{% url 'iframe_fix' %}?cookie_fix=1", "Setting cookie", "location=1,status=1,scrollbars=0,width=50,height=50");
+        var helperWindow = window.open("{% url 'iframe:iframe_fix' %}?cookie_fix=1", "Setting cookie", "location=1,status=1,scrollbars=0,width=50,height=50");
         helperWindow.onunload = function(e) {
             document.getElementById('cookie_link').style.display = 'none';
             document.getElementById('refresh_message').style.display = 'block';


### PR DESCRIPTION
Since Django 1.11 upgrade (#17) app labels need to be included in URL pattern names passed to functions such as `url`. If app labels are missing, `url` et al. will be unable to determine reverses corresponding to URL pattern names (and raise `NoReverseMatch` errors). #17 included necessary changes for LPD urls, but missed adding the appropriate app label to a single `url` call in the iframe app. This PR fixes that issue.

**Test instructions** (targeting production)

*Note that these instructions are targeting a course running on production. Please don't make any changes to the course as part of testing changes from this PR.*

In Firefox or Chrome:

1. If you haven't already, create an account on https://openedx.gse.harvard.edu/.

1. Enroll in [this course](https://openedx.gse.harvard.edu/courses/course-v1:HGSE+F101A+2019_Summer/course/). As of Jun 11th, 2019 the course hasn't launched so you might need elevated permissions for accessing it. In this case, ask @itsjeyd to make you staff on the instance.

In Safari:

1. Clear cache via Develop > Empty Caches. (If the Develop menu doesn't show you can enable it via Safari > Preferences > Advanced > Show Develop menu in menu bar.)

1. Open a new private window.

1. Load the [Complete Your Learner Profile](https://openedx.gse.harvard.edu/courses/course-v1:HGSE+F101A+2019_Summer/jump_to/block-v1:HGSE+F101A+2019_Summer+type@vertical+block@d40b211b2c634491aecb6866f3307547) unit and verify that you're seeing the following content in the body of the LTI component: 

    ![01-iframe-fix-before-clicking-button_cropped](https://user-images.githubusercontent.com/961441/59262778-2ea6f500-8c40-11e9-9150-d1539c588bba.png)

1. Click the "Enable loading of missing content" button and verify that the content changes to match the following screenshot:

    ![02-iframe-fix-after-clicking-button_cropped](https://user-images.githubusercontent.com/961441/59262796-38305d00-8c40-11e9-9ec1-2e4400043738.png)

1. Refresh the page and verify that the LTI component displays the LPD.

1. Navigate away from the [Complete Your Learner Profile](https://openedx.gse.harvard.edu/courses/course-v1:HGSE+F101A+2019_Summer/jump_to/block-v1:HGSE+F101A+2019_Summer+type@vertical+block@d40b211b2c634491aecb6866f3307547) unit and verify that the LTI component displays the LPD right away when you come back to it.

**Reviewers**

- [x] @pkulkark